### PR TITLE
Resolve unknown interface ID

### DIFF
--- a/utils/detectLSPInterface.ts
+++ b/utils/detectLSPInterface.ts
@@ -37,7 +37,7 @@ interface LspTypeOption {
 const lspTypeOptions: Record<Exclude<LSPType, LSPType.Unknown>, LspTypeOption> =
   {
     [LSPType.LSP3]: {
-      interfaceId: INTERFACE_IDS.LSP3UniversalProfile,
+      interfaceId: INTERFACE_IDS.LSP0ERC725Account,
       lsp2Schema: getSupportedStandardObject(lsp3Schema as ERC725JSONSchema[]),
     },
     [LSPType.LSP7]: {


### PR DESCRIPTION
Somehow, TS checks passed this. 

UP's interfaces are LSP0 SC, so we only check LSP3 on the key-value-store, eg. through SupportedStandards afterwards.