### PR TITLE
chore: Change RPC

### DIFF
--- a/shared/config.ts
+++ b/shared/config.ts
@@ -7,7 +7,7 @@ export const NETWORKS: NetworkInfo[] = [
     id: 'testnet',
     name: 'LUKSO Testnet',
     chainId: '0x1069',
-    rpcHttp: 'https://rpc.testnet.lukso.gateway.fm',
+    rpcHttp: 'https://rpc.testnet.lukso.network',
     token: 'LYXt',
   },
   {


### PR DESCRIPTION
### Ticket ID

N/A

### Description

Due to high amount of RPC calls gateway.fm is no longer reliable solution as it has limits. Temporarily we switch to our own RPC until we introduce proper optimizations in RPC calls.
