### PR TITLE
fix: Redirect to `my.universalprofile.cloud` when clicking on logo

### DIFF
--- a/components/AppNavbar.vue
+++ b/components/AppNavbar.vue
@@ -35,6 +35,10 @@ const handleDisconnect = async () => {
   disconnect()
 }
 
+const handleBrandClick = () => {
+  window.open(BASE_MY_UP_CLOUD_URL, '_self')
+}
+
 const extensionStoreData = () => {
   const url = browserInfo().storeLink
   const icon = `logo-${browserInfo().id}`
@@ -56,7 +60,7 @@ const browserSupportExtension = extensionStore.url !== ''
     :is-testnet="IS_TESTNET"
     icon="wallet-outline"
     has-menu
-    @on-brand-click="handleNavigateProfile"
+    @on-brand-click="handleBrandClick"
   >
     <div class="w-full flex items-center justify-end" slot="desktop">
       <lukso-button

--- a/shared/config.ts
+++ b/shared/config.ts
@@ -66,3 +66,6 @@ export const EXTENSION_STORE_LINKS = {
 // transaction default gas values
 export const DEFAULT_GAS = 5_000_000
 export const DEFAULT_GAS_PRICE = '10000000000'
+
+// base my universalprofile address
+export const BASE_MY_UP_CLOUD_URL = 'https://my.universalprofile.cloud/'

--- a/tests/e2e/lyx-details.spec.ts
+++ b/tests/e2e/lyx-details.spec.ts
@@ -4,9 +4,9 @@ import { test } from './helpers/fixtures'
 
 test('user can see lyx details page when not connected', async ({ page }) => {
   await page.goto('/0x64DE43F67e533b59A5791E6aB1e5a80626E10710/lyx-details')
+  await page.waitForLoadState('networkidle')
+  await expect(page).toHaveScreenshot('lyx-details-disconnected.png')
   await expect(page).toHaveURL(
     '/0x64DE43F67e533b59A5791E6aB1e5a80626E10710/lyx-details'
   )
-  await page.waitForLoadState('networkidle')
-  await expect(page).toHaveScreenshot('lyx-details-disconnected.png')
 })


### PR DESCRIPTION
### Ticket ID

[DEV-8514](https://app.clickup.com/t/2645698/DEV-8514)

### Description

Brand click should redirect to `my.universalprofile.cloud`
