### PR TITLE
fix: reload page after network switch

### DIFF
--- a/components/AppFooterNetworkSelect.vue
+++ b/components/AppFooterNetworkSelect.vue
@@ -23,11 +23,12 @@ watchEffect(() => {
   }
 })
 
-const handleNetworkChange = (event: CustomEvent) => {
+const handleNetworkChange = async (event: CustomEvent) => {
   const selectedNetwork = event.detail.value as SelectStringOption
   selectedNetwork.id && (selectedChainId.value = selectedNetwork.id)
   disconnect()
-  navigateTo(homeRoute())
+  await navigateTo(homeRoute())
+  location.reload()
 }
 </script>
 


### PR DESCRIPTION
### Ticket ID

### Description

- reload ensure the app is reset upon network switch. Currently it sometimes land in weird state where profile is seen as EoA
