### PR TITLE
fix: add fix for bytes verifiableuri + improve error

### DIFF
--- a/utils/validateLsp3Metadata.ts
+++ b/utils/validateLsp3Metadata.ts
@@ -11,10 +11,12 @@ export const validateLsp3Metadata = (
   let backgroundImage: ImageMetadata[] = []
 
   const lsp3Profile = LSP3Metadata?.value?.LSP3Profile as LSP3ProfileMetadata
-  const name = validateName(lsp3Profile.name)
-  const tags = validateTags(lsp3Profile.tags)
-  const links = validateLinks(lsp3Profile.links)
-  const description = validateDescription(lsp3Profile.description)
+  const name = lsp3Profile?.name ? validateName(lsp3Profile.name) : ''
+  const tags = lsp3Profile?.tags ? validateTags(lsp3Profile.tags) : []
+  const links = lsp3Profile?.links ? validateLinks(lsp3Profile.links) : []
+  const description = lsp3Profile?.description
+    ? validateDescription(lsp3Profile.description)
+    : ''
 
   if (lsp3Profile?.profileImage?.length) {
     const imageIsValid = validateImages(lsp3Profile?.profileImage)


### PR DESCRIPTION
This adds a compatibility with profiles encoded with `keccak256(bytes)`.

Also add more security for undefined var in the profile JSON which would cause issues on the whole page.