### PR TITLE
chore: set gh action timeout to 15min

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   test:
-    timeout-minutes: 60
+    timeout-minutes: 15
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
There is this bug when CI is stuck on install.

In a normal working mode, the CI never takes more than 7min to perform. So 15min is double that. We don't need to have 60min timeout. After 10min we know already that something is off.