### PR TITLE
chore: remove custom component warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "typechain": "^8.3.2",
     "typescript": "5.3.3",
     "util": "0.12.5",
+    "vue": "^3.4.6",
     "web3": "~1.10.3",
     "web3-utils": "~1.10.3",
     "yata-fetch": "2.1.5"

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "typescript": "5.3.3",
     "util": "0.12.5",
     "vue": "^3.4.6",
+    "vue-router": "^4.2.5",
     "web3": "~1.10.3",
     "web3-utils": "~1.10.3",
     "yata-fetch": "2.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3661,6 +3661,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vue/compiler-core@npm:3.4.6":
+  version: 3.4.6
+  resolution: "@vue/compiler-core@npm:3.4.6"
+  dependencies:
+    "@babel/parser": "npm:^7.23.6"
+    "@vue/shared": "npm:3.4.6"
+    entities: "npm:^4.5.0"
+    estree-walker: "npm:^2.0.2"
+    source-map-js: "npm:^1.0.2"
+  checksum: bc88e5cd36ec8fcb87af11086f6db07ac4ebb9be97a8a6c22200f8494bc606acf8a4795649ef70da7f29ce39483f3533ef7eafa347c4d911ec60b66a520e3129
+  languageName: node
+  linkType: hard
+
 "@vue/compiler-dom@npm:3.4.3, @vue/compiler-dom@npm:^3.3.4":
   version: 3.4.3
   resolution: "@vue/compiler-dom@npm:3.4.3"
@@ -3668,6 +3681,16 @@ __metadata:
     "@vue/compiler-core": "npm:3.4.3"
     "@vue/shared": "npm:3.4.3"
   checksum: c08642c104b580081872d3e6f0be52f8da76edb94380780e5f5a5ac84bae161f2a6e022cfd5fd31b3be2425fbc1c6765389b37821ce25e52813696d95d72ed46
+  languageName: node
+  linkType: hard
+
+"@vue/compiler-dom@npm:3.4.6":
+  version: 3.4.6
+  resolution: "@vue/compiler-dom@npm:3.4.6"
+  dependencies:
+    "@vue/compiler-core": "npm:3.4.6"
+    "@vue/shared": "npm:3.4.6"
+  checksum: e296658a4dc77daab3dd0959a809e45d636236aaac56163b6b79275ee24f5d8621b41a6a89d649dfa65d9e1fdca350fea2f8baf9deec1e0c556b4dbdef8f4519
   languageName: node
   linkType: hard
 
@@ -3688,6 +3711,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vue/compiler-sfc@npm:3.4.6":
+  version: 3.4.6
+  resolution: "@vue/compiler-sfc@npm:3.4.6"
+  dependencies:
+    "@babel/parser": "npm:^7.23.6"
+    "@vue/compiler-core": "npm:3.4.6"
+    "@vue/compiler-dom": "npm:3.4.6"
+    "@vue/compiler-ssr": "npm:3.4.6"
+    "@vue/shared": "npm:3.4.6"
+    estree-walker: "npm:^2.0.2"
+    magic-string: "npm:^0.30.5"
+    postcss: "npm:^8.4.32"
+    source-map-js: "npm:^1.0.2"
+  checksum: 9cf1ef9f7fb0ea570fec5b59e145971a0efd44fb0a07af3f781fe0e6bcecd83447efe2a6b8a602833e3bc911092a3f069d2649d72ed4049b3e7556f8608bcba3
+  languageName: node
+  linkType: hard
+
 "@vue/compiler-ssr@npm:3.4.3":
   version: 3.4.3
   resolution: "@vue/compiler-ssr@npm:3.4.3"
@@ -3695,6 +3735,16 @@ __metadata:
     "@vue/compiler-dom": "npm:3.4.3"
     "@vue/shared": "npm:3.4.3"
   checksum: ad5fef87575852489036eed614d3692f2c69a29c54be27dbf651ddf21b635a2f95a6ace95e1cc17bc8d74d409f2453e8cda0e29ac9c7429e9bcd6920a8222f4d
+  languageName: node
+  linkType: hard
+
+"@vue/compiler-ssr@npm:3.4.6":
+  version: 3.4.6
+  resolution: "@vue/compiler-ssr@npm:3.4.6"
+  dependencies:
+    "@vue/compiler-dom": "npm:3.4.6"
+    "@vue/shared": "npm:3.4.6"
+  checksum: 04adb0d7df1d20fec0de0e57dc9979884e4014b513173923ea86edb4780092c3ca2e145f8276a0b51816b305d9deff5cb820fa3096a4186cd356d27f9d564491
   languageName: node
   linkType: hard
 
@@ -3714,6 +3764,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vue/reactivity@npm:3.4.6":
+  version: 3.4.6
+  resolution: "@vue/reactivity@npm:3.4.6"
+  dependencies:
+    "@vue/shared": "npm:3.4.6"
+  checksum: 19b6c55374defd35ddc74087c3a188354900d45aa37944d4128b86430e09cb7c7e84632e55e8c5b1d52fe0ddb416738c1c3134ea846bc3208fe357288a7289fa
+  languageName: node
+  linkType: hard
+
 "@vue/runtime-core@npm:3.4.3":
   version: 3.4.3
   resolution: "@vue/runtime-core@npm:3.4.3"
@@ -3721,6 +3780,16 @@ __metadata:
     "@vue/reactivity": "npm:3.4.3"
     "@vue/shared": "npm:3.4.3"
   checksum: 830082390162c2b264eaf79fc5b7b5320ee60c1bd95d836079ff980202537fb01bf24b2a39ddf139a007d8db6ed0bcb13eeb55ee8e6152b4b0ccd63e53022e12
+  languageName: node
+  linkType: hard
+
+"@vue/runtime-core@npm:3.4.6":
+  version: 3.4.6
+  resolution: "@vue/runtime-core@npm:3.4.6"
+  dependencies:
+    "@vue/reactivity": "npm:3.4.6"
+    "@vue/shared": "npm:3.4.6"
+  checksum: 73a70ca0af12bd00a3eee4326731759ae8cd0cf42fb13834f0e60bdff6e293dc3c943733f5fe89f867a0293014598a718ed1b183115a2b55bf6592b609ec6e9f
   languageName: node
   linkType: hard
 
@@ -3732,6 +3801,17 @@ __metadata:
     "@vue/shared": "npm:3.4.3"
     csstype: "npm:^3.1.3"
   checksum: 3f5cb11e78dc82327cbfc6c884ca1d7e76856d470ed3767316b29cdc63a04a6a703c3ba76e1d9f1bb4c832d2b49e6b7d210ba0db992492a726555628afb9e1bf
+  languageName: node
+  linkType: hard
+
+"@vue/runtime-dom@npm:3.4.6":
+  version: 3.4.6
+  resolution: "@vue/runtime-dom@npm:3.4.6"
+  dependencies:
+    "@vue/runtime-core": "npm:3.4.6"
+    "@vue/shared": "npm:3.4.6"
+    csstype: "npm:^3.1.3"
+  checksum: c1798dd13ecc8ed8c4a7678c275215d487360dc951e6f1a72f9136326cf70d11271f8d5c5f328e139f52d5e0c4c66a83313827fc5731131d19fbe31a4e1853b1
   languageName: node
   linkType: hard
 
@@ -3747,10 +3827,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vue/server-renderer@npm:3.4.6":
+  version: 3.4.6
+  resolution: "@vue/server-renderer@npm:3.4.6"
+  dependencies:
+    "@vue/compiler-ssr": "npm:3.4.6"
+    "@vue/shared": "npm:3.4.6"
+  peerDependencies:
+    vue: 3.4.6
+  checksum: 9072644ac4ec4f4d07b5fe1f26bf7c3152e0b474cfb8bf7b8a2ee8049ff3bfa058be615ddf0318c21ad6cd2c5abdbb952b7f840c22d11abb48417ae843424825
+  languageName: node
+  linkType: hard
+
 "@vue/shared@npm:3.4.3, @vue/shared@npm:^3.3.13":
   version: 3.4.3
   resolution: "@vue/shared@npm:3.4.3"
   checksum: 69b9f7f9d2bc007d22d816cd378f4ea0656de44c0ce0e0ad9c733966ab066df10151e5c48fbc070895e0edaadf41ab33bf4f65a95c591fce8eb3f53cd0f265e2
+  languageName: node
+  linkType: hard
+
+"@vue/shared@npm:3.4.6":
+  version: 3.4.6
+  resolution: "@vue/shared@npm:3.4.6"
+  checksum: 3fc06b3939c7bf33c7c3a16f0aff988944f09efa537c9dc778c90ce15452a0bde79e31e74dcb305116aa6f2feb5184d12e16c9af74cdbfc47e24f0a4624bf3f4
   languageName: node
   linkType: hard
 
@@ -16110,6 +16209,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vue@npm:^3.4.6":
+  version: 3.4.6
+  resolution: "vue@npm:3.4.6"
+  dependencies:
+    "@vue/compiler-dom": "npm:3.4.6"
+    "@vue/compiler-sfc": "npm:3.4.6"
+    "@vue/runtime-dom": "npm:3.4.6"
+    "@vue/server-renderer": "npm:3.4.6"
+    "@vue/shared": "npm:3.4.6"
+  peerDependencies:
+    typescript: "*"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: c15b4d33540afbfdf0727bba327b8af31695068f43583dab3617e9ec3cbc14e9f144baea617454ce1e1c2af8ddd823c6459aa0386905ffe0b91f5e61ee63a350
+  languageName: node
+  linkType: hard
+
 "wallet.universalprofile.cloud@workspace:.":
   version: 0.0.0-use.local
   resolution: "wallet.universalprofile.cloud@workspace:."
@@ -16177,6 +16294,7 @@ __metadata:
     typechain: "npm:^8.3.2"
     typescript: "npm:5.3.3"
     util: "npm:0.12.5"
+    vue: "npm:^3.4.6"
     web3: "npm:~1.10.3"
     web3-utils: "npm:~1.10.3"
     yata-fetch: "npm:2.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16295,6 +16295,7 @@ __metadata:
     typescript: "npm:5.3.3"
     util: "npm:0.12.5"
     vue: "npm:^3.4.6"
+    vue-router: "npm:^4.2.5"
     web3: "npm:~1.10.3"
     web3-utils: "npm:~1.10.3"
     yata-fetch: "npm:2.1.5"


### PR DESCRIPTION
### Ticket ID

### Description

- console is flooded with custom component warnings, apparently `vue` shipped with `nuxt` doesn't pick up the config properly, adding explicit dependency fixes that.