### PR TITLE
fix: Profile appear as anonymous when decoding asset key fails

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -91,23 +91,31 @@ const setupCurrencies = async () => {
 }
 
 const setupViewedProfile = async () => {
-  try {
-    const profileAddress = useRouter().currentRoute.value.params?.profileAddress
+  const profileAddress = useRouter().currentRoute.value.params?.profileAddress
 
-    if (profileAddress) {
-      if (isAddress(profileAddress)) {
-        await fetchProfile(profileAddress)
-        await fetchAssets(profileAddress)
-      } else {
-        navigateTo(notFoundRoute())
-      }
+  // verify profile address
+  if (profileAddress) {
+    if (!isAddress(profileAddress)) {
+      navigateTo(notFoundRoute())
     }
+  }
+
+  // fetch profile metadata
+  try {
+    await fetchProfile(profileAddress)
   } catch (error: unknown) {
     console.error(error)
 
     if (error instanceof EoAError) {
       navigateTo(notFoundRoute()) // TODO we might want to inform user about EoA instead showing 404
     }
+  }
+
+  // fetch asset metadata
+  try {
+    await fetchAssets(profileAddress)
+  } catch (error) {
+    console.error(error)
   }
 }
 

--- a/tests/unit/utils/validators.spec.ts
+++ b/tests/unit/utils/validators.spec.ts
@@ -3,6 +3,7 @@ import {
   assertAddress,
   assertAddresses,
   assertString,
+  assertArray,
 } from '../../../utils/validators'
 
 test.describe('assertAddress', () => {
@@ -18,9 +19,11 @@ test.describe('assertAddress', () => {
 
   test('throw when address is missing', async ({ page }) => {
     try {
-      assertAddress()
+      assertAddress(undefined)
     } catch (error) {
-      expect((error as unknown as Error).message).toBe(`missing  address`)
+      expect((error as unknown as Error).message).toBe(
+        `undefined is not a string`
+      )
     }
   })
 
@@ -47,9 +50,11 @@ test.describe('assertAddresses', () => {
 
   test('throw when address is missing', async ({ page }) => {
     try {
-      assertAddresses()
+      assertAddresses(undefined)
     } catch (error) {
-      expect((error as unknown as Error).message).toBe(`missing addresses`)
+      expect((error as unknown as Error).message).toBe(
+        `undefined is not an  array`
+      )
     }
   })
 
@@ -84,5 +89,21 @@ test.describe('assertString', () => {
 
   test('pass when value is a string', async ({ page }) => {
     expect(assertString('asdf')).toBeUndefined()
+  })
+})
+
+test.describe('assertArray', () => {
+  test('throw when value is not array', async ({ page }) => {
+    try {
+      assertArray(123, 'users')
+    } catch (error) {
+      expect((error as unknown as Error).message).toBe(
+        `123 is not an users array`
+      )
+    }
+  })
+
+  test('pass when value is an array', async ({ page }) => {
+    expect(assertArray([1, 2, 'asdf'])).toBeUndefined()
   })
 })

--- a/utils/fetchAssets.ts
+++ b/utils/fetchAssets.ts
@@ -1,21 +1,55 @@
+import LSP3ProfileMetadata from '@erc725/erc725.js/schemas/LSP3ProfileMetadata.json'
+
 import { AssetRepository } from '@/repositories/asset'
+
+import type { ERC725JSONSchema } from '@erc725/erc725.js'
 
 export const fetchAssets = async (profileAddress: Address) => {
   const { profile } = useProfile(profileAddress)
+  const profileRepo = useRepo(ProfileRepository)
   const assetRepo = useRepo(AssetRepository)
-  const { receivedAssetAddresses, issuedAssetAddresses } = profile.value || {}
+  const { getInstance } = useErc725()
+  const erc725 = getInstance(
+    profileAddress,
+    LSP3ProfileMetadata as ERC725JSONSchema[]
+  )
   const { isLoadingAssets } = storeToRefs(useAppStore())
+  let receivedAssets, issuedAssets
 
+  // we split LSP5 and LSP12 into separate catch blocks so we can handle them individually and even if
+  // one fails, the other is still handled.
   try {
     isLoadingAssets.value = true
 
-    receivedAssetAddresses &&
-      (await assetRepo.loadAssets(receivedAssetAddresses, profileAddress))
-    issuedAssetAddresses &&
-      (await assetRepo.loadAssets(issuedAssetAddresses, profileAddress))
+    try {
+      receivedAssets = (await erc725.fetchData('LSP5ReceivedAssets[]'))?.value
+      assertArray(receivedAssets)
+      assertAddresses(receivedAssets)
+
+      receivedAssets &&
+        (await assetRepo.loadAssets(receivedAssets, profileAddress))
+    } catch (error) {
+      throw error
+    }
+
+    try {
+      issuedAssets = (await erc725.fetchData('LSP12IssuedAssets[]'))?.value
+      assertArray(issuedAssets)
+      assertAddresses(issuedAssets)
+
+      issuedAssets && (await assetRepo.loadAssets(issuedAssets, profileAddress))
+    } catch (error) {
+      throw error
+    }
   } catch (error) {
     console.error(error)
   } finally {
+    profileRepo.saveProfile({
+      ...profile.value,
+      receivedAssetAddresses: receivedAssets,
+      issuedAssetAddresses: issuedAssets,
+    })
+
     isLoadingAssets.value = false
   }
 }

--- a/utils/fetchAssets.ts
+++ b/utils/fetchAssets.ts
@@ -41,15 +41,15 @@ export const fetchAssets = async (profileAddress: Address) => {
     } catch (error) {
       throw error
     }
-  } catch (error) {
-    console.error(error)
-  } finally {
+
     profileRepo.saveProfile({
       ...profile.value,
       receivedAssetAddresses: receivedAssets,
       issuedAssetAddresses: issuedAssets,
     })
-
+  } catch (error) {
+    console.error(error)
+  } finally {
     isLoadingAssets.value = false
   }
 }

--- a/utils/fetchLsp3Profile.ts
+++ b/utils/fetchLsp3Profile.ts
@@ -12,14 +12,8 @@ export const fetchLsp3Profile = async (
     profileAddress,
     LSP3ProfileMetadata as ERC725JSONSchema[]
   )
-  const getData = (await fetchLsp3ProfileData(profileAddress))[0]
-  const profileData = await erc725.fetchData([
-    'LSP3Profile',
-    'LSP5ReceivedAssets[]',
-    'LSP12IssuedAssets[]',
-  ])
-
-  const [profileMetadata, receivedAssets, issuedAssets] = profileData
+  const getData = await fetchLsp3ProfileData(profileAddress)
+  const profileMetadata = await erc725.fetchData('LSP3Profile')
 
   // NOTE: Some profiles have been encoded with keccak256(bytes) instead of keccak256(utf8)
   // This little trick allows a smooth transition to the new encoding
@@ -63,8 +57,6 @@ export const fetchLsp3Profile = async (
     backgroundImage,
     profileImageId,
     backgroundImageId,
-    receivedAssetAddresses: receivedAssets.value as Address[],
-    issuedAssetAddresses: issuedAssets.value as Address[],
     hash,
     verification,
   }
@@ -76,11 +68,7 @@ export const fetchLsp3ProfileData = async (profileAddress: string) => {
     profileAddress,
     LSP3ProfileMetadata as ERC725JSONSchema[]
   )
-  const profileData = await erc725.getData([
-    'LSP3Profile',
-    'LSP5ReceivedAssets[]',
-    'LSP12IssuedAssets[]',
-  ])
+  const profileData = await erc725.getData('LSP3Profile')
 
   return profileData
 }

--- a/utils/fetchProfile.ts
+++ b/utils/fetchProfile.ts
@@ -11,14 +11,7 @@ export const fetchProfile = async (profileAddress: Address) => {
   const storeProfile = profileRepo.getProfileAndImages(profileAddress)
 
   if (storeProfile) {
-    const [profileData, receivedAssetAddresses, issuedAssetAddresses] =
-      await fetchLsp3ProfileData(profileAddress)
-
-    // update profile received and issued assets array
-    useRepo(ProfileModel).where('address', profileAddress).update({
-      receivedAssetAddresses: receivedAssetAddresses.value,
-      issuedAssetAddresses: issuedAssetAddresses.value,
-    })
+    const profileData = await fetchLsp3ProfileData(profileAddress)
 
     // check if profile metadata hash has changed
     if (getHash(profileData.value) === getHash(storeProfile)) {

--- a/utils/validators.ts
+++ b/utils/validators.ts
@@ -10,12 +10,10 @@ const { isAddress } = web3utils // need to import like this due to CommonJS modu
  * @returns - throws an error if the value is not an address
  */
 export function assertAddress(
-  value?: string,
+  value: unknown,
   name = ''
 ): asserts value is Address {
-  if (!value) {
-    throw Error(`missing ${name} address`)
-  }
+  assertString(value)
 
   if (!isAddress(value)) {
     throw Error(`${value} is not an ${name} address`)
@@ -31,18 +29,29 @@ export function assertAddress(
  * @returns - throws an error if the value is not an array of addresses
  */
 export function assertAddresses(
-  value?: string[],
+  value: unknown,
   name = ''
 ): asserts value is Address[] {
-  if (!value) {
-    throw Error(`missing addresses`)
-  }
-
-  if (!Array.isArray(value)) {
-    throw Error(`is not an ${name} array`)
-  }
+  assertArray(value, name)
 
   return value.forEach(value => assertAddress(value, name))
+}
+
+/**
+ * Ensures that the given value is an array,
+ * otherwise throws an error.
+ *
+ * @param value - the value to check
+ * @param name - the name of the value
+ * @returns - throws an error if the value is not an array
+ */
+export function assertArray(
+  value: unknown,
+  name = ''
+): asserts value is Array<any> {
+  if (!Array.isArray(value)) {
+    throw Error(`${value} is not an ${name} array`)
+  }
 }
 
 /**
@@ -52,7 +61,7 @@ export function assertAddresses(
  * @param value - the value to check
  * @returns - throws an error if the value is not a string
  */
-export function assertString(value: any): asserts value is string {
+export function assertString(value: unknown): asserts value is string {
   if (typeof value !== 'string') {
     throw Error(`${value} is not a string`)
   }


### PR DESCRIPTION
### Ticket ID

[DEV-9566](https://app.clickup.com/t/86bx18mt2)

### Description

- split fetching keys (LSP3, LSP5, LSP12) so when one fails it won't affect the others
