### PR TITLE
fix: Limit input length based on asset decimals

### DIFF
--- a/components/SendCardAmount.vue
+++ b/components/SendCardAmount.vue
@@ -13,7 +13,7 @@ const handleKeyDown = (customEvent: CustomEvent) => {
   const assetBalanceBN = new BigNumber(
     `${fromWeiWithDecimals(asset.value?.balance || '0', asset.value?.decimals)}`
   )
-  const maxDecimalPlaces = 6
+  const maxDecimalPlaces = asset.value?.decimals
 
   // check for allowed keys or if user press CMD+A
   if (allowedKeys.includes(key) || (event.metaKey && key === 'a')) {


### PR DESCRIPTION
### Ticket ID

[DEV-9569](https://app.clickup.com/t/2645698/DEV-9569)

### Description

- validate decimal places based on the asset `decimals` value
