### PR TITLE
fix: display only tokens with balance

### DIFF
--- a/repositories/asset.ts
+++ b/repositories/asset.ts
@@ -71,6 +71,9 @@ export class AssetRepository extends Repository<AssetModel> {
       .where('standard', 'LSP7DigitalAsset')
       .where('address', viewedProfile.value.receivedAssetAddresses)
       .where('chainId', selectedChainId.value)
+      .where(token => {
+        return token.balance !== '0'
+      })
       .get()
   }
 
@@ -86,6 +89,9 @@ export class AssetRepository extends Repository<AssetModel> {
       .where('standard', 'LSP7DigitalAsset')
       .where('address', viewedProfile.value.issuedAssetAddresses)
       .where('chainId', selectedChainId.value)
+      .where(token => {
+        return token.balance !== '0'
+      })
       .get()
   }
 


### PR DESCRIPTION
### Ticket ID

[DEV-9562](https://app.clickup.com/t/2645698/DEV-9562)

### Description

- atm we displayed all tokens from `LSP5` array but we should filter out the one without balance
