### PR TITLE
fix: wrong display of LYX balance in detailed view

### DIFF
--- a/pages/[profileAddress]/lyx-details.vue
+++ b/pages/[profileAddress]/lyx-details.vue
@@ -49,12 +49,13 @@ const handleSendLyx = () => {
           v-if="
             isConnected &&
             viewedProfile?.address === connectedProfile?.address &&
+            connectedProfile?.balance !== '0' &&
             connectedProfile
           "
         >
           <AssetOwnInfo
             :address="connectedProfile.address"
-            :amount="viewedProfile?.balance"
+            :balance="connectedProfile.balance"
             :symbol="currentNetwork.token.symbol"
             :decimals="ASSET_LYX_DECIMALS"
             :profile-image-url="profileImageUrl"

--- a/pages/asset/[nftAddress]/tokenId/[tokenId].vue
+++ b/pages/asset/[nftAddress]/tokenId/[tokenId].vue
@@ -24,6 +24,7 @@ const isOwned = computed(() => {
     isConnected &&
     connectedProfile &&
     asset.value?.address &&
+    asset.value?.balance &&
     connectedProfile.value?.receivedAssetAddresses?.includes(
       asset.value?.address
     )

--- a/pages/asset/[tokenAddress].vue
+++ b/pages/asset/[tokenAddress].vue
@@ -39,6 +39,18 @@ const handleSendAsset = (event: Event) => {
     console.error(error)
   }
 }
+
+const isOwned = computed(() => {
+  return (
+    isConnected &&
+    connectedProfile &&
+    asset.value?.address &&
+    asset.value?.balance !== '0' &&
+    connectedProfile.value?.receivedAssetAddresses?.includes(
+      asset.value?.address
+    )
+  )
+})
 </script>
 
 <template>
@@ -64,16 +76,9 @@ const handleSendAsset = (event: Event) => {
             ></lukso-profile>
           </div>
         </lukso-card>
-        <div
-          v-if="
-            isConnected &&
-            connectedProfile &&
-            asset?.address &&
-            connectedProfile?.receivedAssetAddresses?.includes(asset?.address)
-          "
-        >
+        <div v-if="isOwned">
           <AssetOwnInfo
-            :address="connectedProfile.address"
+            :address="connectedProfile?.address"
             :balance="asset?.balance"
             :symbol="asset?.symbol"
             :decimals="asset?.decimals"


### PR DESCRIPTION
### Ticket ID

[DEV-9640](https://app.clickup.com/t/2645698/DEV-9640)

### Description

- fix for showing owned balance in LYX details
- small refactors to owned section in assets
