### PR TITLE
fix: Convert object data for `links` and `tags` from Algolia into array

### DIFF
--- a/utils/fetchLsp7Asset.ts
+++ b/utils/fetchLsp7Asset.ts
@@ -62,6 +62,9 @@ export const createLsp7Object = async (
     creator?.profile?.address && creatorIds.push(creator.profile.address)
   })
 
+  // links are passed as object instead of array so we need to convert
+  const linksParsed = links && Object.values(links)
+
   return {
     address,
     name,
@@ -69,7 +72,7 @@ export const createLsp7Object = async (
     balance,
     decimals,
     tokenSupply,
-    links,
+    links: linksParsed,
     description,
     standard: 'LSP7DigitalAsset',
     icon,

--- a/utils/fetchProfile.ts
+++ b/utils/fetchProfile.ts
@@ -59,6 +59,10 @@ const createProfileObject = async (
 ): Promise<Profile> => {
   const { links, tags, description, name } = metadata || {}
 
+  // links and tags are passed as object instead of array so we need to convert
+  const linksParsed = links && Object.values(links)
+  const tagsParsed = tags && Object.values(tags)
+
   // get best image from collection based on height criteria
   const profileImage =
     metadata?.profileImage &&
@@ -81,8 +85,8 @@ const createProfileObject = async (
     address,
     name,
     balance,
-    links,
-    tags,
+    links: linksParsed,
+    tags: tagsParsed,
     description,
     profileImage,
     backgroundImage,


### PR DESCRIPTION
### Ticket ID

[DEV-9583](https://app.clickup.com/t/2645698/DEV-9583)

### Description

- since Algolia return data as objects we need to convert into array
- LSP8 conversion will be in other PR
