### PR TITLE
fix: Truncate long token ids

### DIFF
--- a/components/AssetAddress.vue
+++ b/components/AssetAddress.vue
@@ -1,11 +1,22 @@
 <script setup lang="ts">
 import makeBlockie from 'ethereum-blockies-base64'
+import { sliceAddress } from '@lukso/web-components/tools'
 
 type Props = {
   address: Address
 }
 
-defineProps<Props>()
+const props = defineProps<Props>()
+const { isMobile } = useDevice()
+
+const truncateAddress = computed(() => {
+  let addressLength = 66
+
+  if (isMobile) {
+    addressLength = 8
+  }
+  return sliceAddress(props.address, addressLength)
+})
 </script>
 
 <template>
@@ -22,7 +33,7 @@ defineProps<Props>()
           alt=""
           class="bottom-0 right-0 h-6 w-6 rounded-full shadow-neutral-above-shadow-1xl outline outline-2 outline-neutral-100"
         />
-        <div class="paragraph-ptmono-12-bold ml-2">{{ address }}</div>
+        <div class="paragraph-ptmono-12-bold ml-2">{{ truncateAddress }}</div>
       </div>
       <div class="flex items-center gap-2">
         <lukso-tooltip

--- a/components/AssetTokenId.vue
+++ b/components/AssetTokenId.vue
@@ -1,16 +1,28 @@
 <script setup lang="ts">
+const { isMobile } = useDevice()
+
 type Props = {
   asset: Asset
 }
 
 defineProps<Props>()
+
+const tokenLength = computed(() => {
+  let tokenLength = 64
+
+  if (isMobile) {
+    tokenLength = 36
+  }
+
+  return tokenLength
+})
 </script>
 
 <template>
   <lukso-tag is-rounded class="mb-8">
     <div class="flex items-center">
       <div class="paragraph-ptmono-12-bold mr-2">
-        {{ prefixedTokenId(asset?.tokenId, asset?.tokenIdFormat) }}
+        {{ prefixedTokenId(asset?.tokenId, asset?.tokenIdFormat, tokenLength) }}
       </div>
       <lukso-tooltip
         variant="light"

--- a/pages/asset/[nftAddress]/tokenId/[tokenId].vue
+++ b/pages/asset/[nftAddress]/tokenId/[tokenId].vue
@@ -23,7 +23,7 @@ const handleSendAsset = (event: Event) => {
 }
 
 const assetTokenId = computed(() => {
-  return prefixedTokenId(asset.value?.tokenId, asset.value?.tokenIdFormat)
+  return prefixedTokenId(asset.value?.tokenId, asset.value?.tokenIdFormat, 36)
 })
 </script>
 


### PR DESCRIPTION
### Ticket ID

[DEV-10056](https://app.clickup.com/t/2645698/DEV-10056)

### Description

- truncate very long token ids in desktop view so they don't break UI
- add even more truncation in mobile view
