### PR TITLE
fix: when sending to EOA dropdown overlap the button

### DIFF
--- a/components/SendCardProfileSearch.vue
+++ b/components/SendCardProfileSearch.vue
@@ -63,6 +63,9 @@ const handleReceiverSearch = async (event: CustomEvent) => {
         address: searchTerm.value,
         type: 'EOA',
       }
+      hasNoResults.value = false
+      isSearchingReceiver.value = false
+      return
     }
   } else {
     receiver.value = undefined


### PR DESCRIPTION
### Ticket ID

[DEV-10239](https://app.clickup.com/t/2645698/DEV-10239)

### Description

- since EoA can't be found in index it show "Profile not found" message. But for EOA we should hide it as it's still valid receipent.
