### PR TITLE
fix: stop loading effect when no results found

### DIFF
--- a/components/AppNavbarProfileSearch.vue
+++ b/components/AppNavbarProfileSearch.vue
@@ -25,6 +25,7 @@ const searchResults = async () => {
 
   if (searchResults.hits.length === 0) {
     hasNoResults.value = true
+    isSearching.value = false
     return
   } else {
     hasNoResults.value = false


### PR DESCRIPTION
### Ticket ID

### Description

- when no user is found we should stop the loading animation