### PR TITLE
fix: allow LSP7 & LSP8 transfers to EOA

### DIFF
--- a/pages/[profileAddress]/send.vue
+++ b/pages/[profileAddress]/send.vue
@@ -21,7 +21,7 @@ const {
 const { isLoadedApp, isConnected, hasSimpleNavbar } = storeToRefs(useAppStore())
 const { setStatus, clearSend } = useSendStore()
 const { showModal } = useModal()
-const { sendTransaction, contract } = useWeb3(PROVIDERS.INJECTED)
+const { sendTransaction, contract, isEoA } = useWeb3(PROVIDERS.INJECTED)
 const amount = computed(() => useRouter().currentRoute.value.query.amount)
 const assetAddress = computed(() => useRouter().currentRoute.value.query.asset)
 const tokenId = computed(() => useRouter().currentRoute.value.query.tokenId)
@@ -96,7 +96,7 @@ const handleSend = async () => {
                 sendAmount.value || '0',
                 sendAsset.value?.decimals
               ),
-              false,
+              isEoA(receiver.value?.address),
               '0x'
             )
             .send({ from: connectedProfile.value.address })
@@ -116,7 +116,7 @@ const handleSend = async () => {
               connectedProfile.value.address,
               receiver.value?.address,
               sendAsset.value.tokenId,
-              false,
+              isEoA(receiver.value?.address),
               '0x'
             )
             .send({ from: connectedProfile.value.address })


### PR DESCRIPTION
### Ticket ID

DEV-10405

### Description

Change the force flag based on type of the receiver address, if its an EOA it should be true otherwise it should be false

[LSP7 transaction](https://explorer.execution.mainnet.lukso.network/tx/0xeb05e976015febf0d6241d35b545036ae3f05f94ff7a76a0e23ba41a88b7dc0b)

<img width="494" alt="Screenshot 2024-04-05 at 13 33 06" src="https://github.com/lukso-network/wallet.universalprofile.cloud/assets/62855857/3edaa1ac-2af0-4c04-89d1-408f28eaa471">

