### PR TITLE
feat: change asset to be sorted by name instead of added date

### DIFF
--- a/pages/[profileAddress]/index.vue
+++ b/pages/[profileAddress]/index.vue
@@ -8,8 +8,23 @@ const { isMobile } = useDevice()
 const viewedProfile = useProfile().getProfile(viewedProfileAddress)
 const allTokens = useProfileAssets()(viewedProfileAddress)
 
+/**
+ * Sort assets ascending (A-Z) by their name
+ *
+ * @returns
+ */
+const allTokensSorted = computed(
+  () =>
+    allTokens.value?.slice().sort((a, b) => {
+      const tokenNameA = a.tokenName || ''
+      const tokenNameB = b.tokenName || ''
+
+      return tokenNameA.localeCompare(tokenNameB)
+    }) || []
+)
+
 const tokensOwned = computed(() =>
-  allTokens.value?.filter(
+  allTokensSorted.value?.filter(
     ({ isOwned, standard, balance, tokenType }) =>
       isOwned &&
       standard === 'LSP7DigitalAsset' &&
@@ -19,7 +34,7 @@ const tokensOwned = computed(() =>
 )
 
 const tokensCreated = computed(() =>
-  allTokens.value?.filter(
+  allTokensSorted.value?.filter(
     ({ isIssued, standard, tokenType }) =>
       isIssued &&
       standard === 'LSP7DigitalAsset' &&
@@ -28,13 +43,13 @@ const tokensCreated = computed(() =>
 )
 
 const nftsOwned = computed(() =>
-  allTokens.value?.filter(
+  allTokensSorted.value?.filter(
     asset => asset.isOwned && isCollectible(asset) && asset.balance !== '0'
   )
 )
 
 const nftsCreated = computed(() =>
-  allTokens.value?.filter(asset => asset.isIssued && isCollectible(asset))
+  allTokensSorted.value?.filter(asset => asset.isIssued && isCollectible(asset))
 )
 
 // tokens


### PR DESCRIPTION
### Ticket ID

[DEV-10766](https://app.clickup.com/t/2645698/DEV-10766)

### Description

We want to have assets more organized before we introduce some sorting options. Thats why new default sorting will be by `name` instead of the date when it was added to profile.
